### PR TITLE
fix: indentation in the mission control mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,7 +67,7 @@ nav:
                   - Canary Checker: ./canary-checker/overview.md
                   - Logging: ./apm-hub/overview.md
                   - Topology: ./topology/overview.md
-        Installation:
+        - Installation:
                 - Installation: ./install.md
                 - Architecture: ./architecture.md
                 - Security: ./security.md


### PR DESCRIPTION
Noticed that the workflow was failing with some config error: https://github.com/flanksource/docs/actions/runs/5414402468/jobs/9841418191#step:5:88

When debugging this locally saw there was a indentation problem in the config.
diff to fix that.