### PR TITLE
Update dry-run docs

### DIFF
--- a/mission-control/docs/integrations/flux/playbooks.md
+++ b/mission-control/docs/integrations/flux/playbooks.md
@@ -103,7 +103,7 @@ To enable the Flux integration you need
     ```
   - Are compatible with your kubernetes API versions and CRD's with:
     ```shell
-    kustomization build | kubectl apply -f - --dry-run=service
+    kustomization build | kubectl apply -f - --dry-run=server
     ```
   - Passes all compliance and governance rule
 - Auto Merge PR's that are safe


### PR DESCRIPTION
## Summary
- fix Flux playbooks doc to use `--dry-run=server`

## Testing
- `make fmt-check`
- `make lint` *(fails: `13 errors, 3 warnings and 51 suggestions in 89 files`)*

------
https://chatgpt.com/codex/tasks/task_e_6840050f77c083228fb5d852970558f4