### PR TITLE
Revert "chore: use / as base url always"

### DIFF
--- a/mission-control/docusaurus.config.ts
+++ b/mission-control/docusaurus.config.ts
@@ -18,8 +18,7 @@ export default async function createConfigAsync() {
     tagline: '',
     // staticDirectories: ['images', 'static'],
     url: 'https://flanksource.com',
-    //baseUrl: process.env.NODE_ENV == "development" || process.env.PREVIEW == "true" ? '/' : '/docs',
-    baseUrl: '/',
+    baseUrl: process.env.NODE_ENV == "development" || process.env.PREVIEW == "true" ? '/' : '/docs',
     organizationName: 'flanksource', // Usually your GitHub org/user name.
     projectName: 'docs', // Usually your repo name.
     favicon: 'img/flanksource-icon.png',


### PR DESCRIPTION
Reverts flanksource/docs#406