### PR TITLE
docs(slack): use typed spec.slack connection instead of URL-based approach

### DIFF
--- a/mission-control/docs/guide/mcp/resources/connection.mdx
+++ b/mission-control/docs/guide/mcp/resources/connection.mdx
@@ -54,15 +54,13 @@ This resource allows you to access detailed information about a specific connect
   "type": "slack",
   "created_at": "2025-01-12T10:15:00Z",
   "updated_at": "2025-01-18T16:45:00Z",
-  "url": "slack://$(password)@$(username)",
-  "username": "notification-bot",
-  "password": "secret://slack/token"
   "properties": {
+    "token": "secret://slack-credentials/BOT_TOKEN",
     "channel": "C1234567890",
     "botName": "Mission Control",
     "color": "#36a64f",
     "icon": ":robot_face:"
-  },
+  }
 }
 ```
 

--- a/mission-control/docs/guide/notifications/channels/slack.mdx
+++ b/mission-control/docs/guide/notifications/channels/slack.mdx
@@ -39,17 +39,6 @@ The Slack notification service uses either [Slack Webhooks](https://api.slack.co
 
 
 
-## Examples
-
-```uri title="Bot API"
-slack://xoxb:123456789012-1234567890123-4mt0t4l1YL3g1T5L4cK70k3N@C001CH4NN3L?color=good&title=Great+News&icon=man-scientist&botname=Shoutrrrbot
-```
-
-```uri title="Hook with color"
-slack://hook:WNA3PBYV6-F20DUQND3RQ-Webc4MAvoacrpPakR8phF0zi@webhook?color=%2300FF00&title=Great+News&icon=man-scientist&botname=Shoutrrrbot
-```
-
-
 ## Create a Slack bot
 
 1. Create a new app
@@ -86,15 +75,15 @@ slack://hook:WNA3PBYV6-F20DUQND3RQ-Webc4MAvoacrpPakR8phF0zi@webhook?color=%2300F
     apiVersion: v1
     kind: Secret
     metadata:
-      name: slack
+      name: slack-credentials
       namespace: default
     stringData:
-      token: xoxb-910094966996-6596865117477-n7iujSYWmHtnTLMmITdm8z06
+      BOT_TOKEN: xoxb-910094966996-6596865117477-n7iujSYWmHtnTLMmITdm8z06
     ```
      <p/>
 5. Create Connection
 
-    Create a new slack connection using that kubernetes secret. The channel that should receive the notification should go into `spec.username` field.
+    Create a new Slack connection using that kubernetes secret.
 
     ```yaml title="slack-connection.yaml"
     apiVersion: mission-control.flanksource.com/v1
@@ -103,16 +92,15 @@ slack://hook:WNA3PBYV6-F20DUQND3RQ-Webc4MAvoacrpPakR8phF0zi@webhook?color=%2300F
       name: slack
       namespace: default
     spec:
-      type: slack
-      url:
-        value: slack://$(password)@$(username)
-      username:
-        value: mission-control-notifications # <-- slack channel name
-      password:
-        valueFrom:
-          secretKeyRef:
-            name: slack
-            key: token
+      slack:
+        token:
+          valueFrom:
+            secretKeyRef:
+              name: slack-credentials
+              key: BOT_TOKEN
+        channel: C0123456789
+        botName: Mission Control
+        icon: ":robot_face:"
     ```
     <p/>
 6. Create the notification CRD


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Slack integration configuration to use token-based authentication with secret references
  * Added new configuration options: channel, botName, and icon fields for Slack connections
  * Refined secret management approach for Slack credentials

<!-- end of auto-generated comment: release notes by coderabbit.ai -->