### PR TITLE
chore: remove git fixture references

### DIFF
--- a/canary-checker/docs/reference/1-git.mdx
+++ b/canary-checker/docs/reference/1-git.mdx
@@ -7,17 +7,18 @@ sidebar_custom_props:
 
 # <Icon name="git" /> Git
 
-<!-- Source: modules/canary-checker/api/v1/checks.go#GitHubCheck -->
+<!-- Source: modules/canary-checker/api/v1/checks.go#GitProtocolCheck -->
 
 <Standard />
 
-Execute as SQL style query against a github repo using [mergestat-lite](https://github.com/mergestat/mergestat-lite).
+Use a `gitProtocol` check to verify repository access with Git credentials.
 
-```yaml file=<rootDir>/modules/canary-checker/fixtures/git/git_check_pass.yaml title='github-check.yaml'
+```yaml file=<rootDir>/modules/canary-checker/fixtures/git/git_pull_push_pass.yaml title='git-protocol-check.yaml'
 ```
 
-<HealthCheck name="github" rows={[
-  {field: "connection", description: "Connection name for GitHub credentials", scheme: 'string'},
-  {field: "githubToken", description: "Github Personal Access Token", scheme: 'EnvVar'},
-  {field: "query", description: "Query to be executed. See [mergestat-lite](https://github.com/mergestat/mergestat-lite) for syntax", scheme: 'string', required: true},
+<HealthCheck name="gitProtocol" rows={[
+  {field: "repository", description: "Git repository URL", scheme: 'string', required: true},
+  {field: "username", description: "Username for repository authentication", scheme: 'EnvVar', required: true},
+  {field: "password", description: "Password or token for repository authentication", scheme: 'EnvVar', required: true},
+  {field: "filename", description: "Optional file name used by the check", scheme: 'string'},
 ]}/>

--- a/mission-control/docs/guide/notifications/events/configs.mdx
+++ b/mission-control/docs/guide/notifications/events/configs.mdx
@@ -48,9 +48,7 @@ The default notification template for health events is:
 
 #### Template
 
-```txt file=<rootDir>/modules/mission-control/notification/templates/config.health
-
-```
+Default content is generated from the notification payload in `modules/mission-control/notification/message.go`.
 
 ## State events
 
@@ -86,9 +84,7 @@ spec:
 
 #### Template
 
-```txt file=<rootDir>/modules/mission-control/notification/templates/config.db.update
-
-```
+Default content is generated from the notification payload in `modules/mission-control/notification/message.go`.
 
 ## Template Variables
 

--- a/mission-control/docs/guide/notifications/events/health-checks.mdx
+++ b/mission-control/docs/guide/notifications/events/health-checks.mdx
@@ -47,9 +47,7 @@ spec:
 
 #### Template
 
-```txt file=<rootDir>/modules/mission-control/notification/templates/check.passed
-
-```
+Default content is generated from the notification payload in `modules/mission-control/notification/message.go`.
 
 ### check.failed
 
@@ -61,9 +59,7 @@ spec:
 
 #### Template
 
-```txt file=<rootDir>/modules/mission-control/notification/templates/check.failed
-
-```
+Default content is generated from the notification payload in `modules/mission-control/notification/message.go`.
 
 ## Template Variables
 


### PR DESCRIPTION
Removed references to git fixtures that were removed in [canary-checker PR #2855.
](https://github.com/flanksource/canary-checker/pull/2855)
The Git check type is now deprecated and those fixtures are no longer available in the canary-checker repository.

References removed:
- canary-checker/docs/reference/1-git.mdx
- mission-control docs notification event pages