### PR TITLE
docs: document /metrics endpoint authentication requirement

### DIFF
--- a/mission-control/docs/integrations/prometheus.mdx
+++ b/mission-control/docs/integrations/prometheus.mdx
@@ -67,11 +67,24 @@ spec:
 
 Mission Control exposes Prometheus metrics for monitoring health checks, notifications, and configuration scraping.
 
+### Authentication
+
+The `/metrics` endpoint requires authentication by default. Prometheus must supply valid credentials when scraping, or you can disable the requirement:
+
+```bash title="Disable metrics authentication"
+helm install mission-control flanksource/mission-control \
+  --set metrics.auth.disabled=true
+```
+
+:::note
+Disabling authentication exposes your metrics endpoint publicly. Only use this setting in trusted network environments.
+:::
+
 ### ServiceMonitor Setup
 
 Enable Prometheus scraping via ServiceMonitor:
 
-```bash
+```bash title="Enable ServiceMonitor"
 helm install mission-control flanksource/mission-control \
   --set serviceMonitor=true
 ```


### PR DESCRIPTION
## Summary

- Documents that the `/metrics` endpoint requires authentication by default
- Adds the `metrics.auth.disabled=true` Helm flag for environments where unauthenticated access is needed
- Includes a security note warning against disabling auth in untrusted network environments

Closes #466

## Files changed

- `mission-control/docs/integrations/prometheus.mdx` — new Authentication section added before ServiceMonitor Setup

## Vale lint

Vale lint: 0 new errors introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Authentication section for Prometheus scraping with documentation on the default authorization requirement for the `/metrics` endpoint.
  * Included Helm configuration snippet and instructions for disabling authentication when needed.
  * Added security guidance warning against exposing metrics publicly except on trusted networks.
  * Improved code block presentation for ServiceMonitor setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->