### PR TITLE
docs(redis): add TLS config and examples

### DIFF
--- a/canary-checker/docs/reference/1-redis.mdx
+++ b/canary-checker/docs/reference/1-redis.mdx
@@ -12,6 +12,7 @@ The Redis check connects to a specified Redis database instance to check its ava
 
 ```yaml title="redis.yaml"  file=<rootDir>/modules/canary-checker/fixtures/datasources/redis_pass.yaml
 ```
+
 <HealthCheck name="redis" connection="url" rows={[
   {field: "url", description: "Redis connection URL", scheme: 'string'},
   {field: "connection", description: "Connection name e.g. connection://redis/prod", scheme: 'string'},
@@ -19,8 +20,75 @@ The Redis check connects to a specified Redis database instance to check its ava
   {field: "password", description: "Password for authentication", scheme: 'EnvVar'},
   {field: "db", description: "Database to be selected after connecting to the server", scheme: 'int'},
   {field: "addr", description: "Redis address (deprecated - use url instead)", scheme: 'string'},
-
+  {
+    field: 'tlsConfig',
+    description: 'TLS and mutual TLS configuration',
+    scheme: '[TLSConfig](#tls-config)'
+  },
 ]}/>
 
+## TLS Config
 
+The `tlsConfig` field enables TLS for the Redis connection. Set `enable: true` to use the system trust store. Use `tlsConfig.ca` to verify with a custom CA. Add `tlsConfig.cert` and `tlsConfig.key` for mutual TLS.
+
+<Fields
+  rows={[
+    {
+      field: 'enable',
+      description: 'Explicitly enable TLS when no other TLS field is set (e.g. for publicly-trusted servers that need no CA).',
+      scheme: 'bool'
+    },
+    {
+      field: 'ca',
+      description: 'PEM encoded CA certificate to verify the server certificate',
+      scheme: 'EnvVar'
+    },
+    {
+      field: 'cert',
+      description: 'PEM encoded client certificate for mutual TLS',
+      scheme: 'EnvVar'
+    },
+    {
+      field: 'key',
+      description: 'PEM encoded client private key for mutual TLS',
+      scheme: 'EnvVar'
+    },
+    {
+      field: 'handshakeTimeout',
+      description: 'TLS handshake timeout. Defaults to 10 seconds',
+      scheme: 'Duration'
+    },
+    {
+      field: 'insecureSkipVerify',
+      description: 'Skip verification of the server certificate chain and host name',
+      scheme: 'bool'
+    },
+  ]}
+/>
+
+## Examples
+
+### Redis with TLS (system trust store)
+
+```yaml title="redis-tls.yaml" file=<rootDir>/modules/canary-checker/fixtures/datasources/redis-tls.yaml
+
+```
+
+### Redis with custom CA
+
+```yaml title="redis-custom-ca.yaml" file=<rootDir>/modules/canary-checker/fixtures/datasources/redis-custom-ca.yaml
+
+```
+
+### Redis with mutual TLS
+
+```yaml title="redis-mtls.yaml" file=<rootDir>/modules/canary-checker/fixtures/datasources/redis-mtls.yaml
+
+```
+
+### Redis with insecure TLS (skip verification)
+
+```yaml title="redis-tls-insecure.yaml" file=<rootDir>/modules/canary-checker/fixtures/datasources/redis-tls-insecure.yaml
+
+```
 

--- a/canary-checker/docs/reference/1-redis.mdx
+++ b/canary-checker/docs/reference/1-redis.mdx
@@ -31,6 +31,11 @@ The Redis check connects to a specified Redis database instance to check its ava
 
 The `tlsConfig` field enables TLS for the Redis connection. Set `enable: true` to use the system trust store. Use `tlsConfig.ca` to verify with a custom CA. Add `tlsConfig.cert` and `tlsConfig.key` for mutual TLS.
 
+:::note
+Native Redis TLS connection string formats are **not** supported — e.g. `rediss://` scheme,
+`ssl=true`, or other query-string flags in the URL. TLS must be configured explicitly via `tlsConfig`.
+:::
+
 <Fields
   rows={[
     {


### PR DESCRIPTION
Document tlsConfig field with enable, ca, cert, key, handshakeTimeout, and insecureSkipVerify. Add examples for all four TLS variants: system trust store, custom CA, mutual TLS, and insecure.

related: https://github.com/flanksource/canary-checker/issues/2982

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Redis TLS configuration documentation with setup examples, including custom CA certificates, mutual TLS, and verification options.

* **Chores**
  * Updated canary-checker module to latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->