### PR TITLE
docs(github): document repository selectors

### DIFF
--- a/mission-control/docs/guide/config-db/scrapers/github.md
+++ b/mission-control/docs/guide/config-db/scrapers/github.md
@@ -24,7 +24,7 @@ The GitHub Actions scraper creates configuration items from GitHub Actions workf
 
 The GitHub Repository scraper creates `GitHub::Repository` config items and optionally fetches security alerts (Dependabot, code scanning, secret scanning) and OpenSSF Scorecard data as analyses.
 
-```yaml title='github.yaml'
+```yaml title='github.yaml' file=<rootDir>/modules/config-db/fixtures/github.yaml
 
 ```
 
@@ -39,10 +39,20 @@ The GitHub Repository scraper creates `GitHub::Repository` config items and opti
 
 ### GitHubRepository
 
-| Field   | Description             | Scheme   | Required |
-| ------- | ----------------------- | -------- | -------- |
-| `owner` | GitHub repository owner | `string` | `true`   |
-| `repo`  | GitHub repository name  | `string` | `true`   |
+| Field   | Description                                                                                                               | Scheme   | Required |
+| ------- | ------------------------------------------------------------------------------------------------------------------------- | -------- | -------- |
+| `owner` | GitHub repository owner                                                                                                   | `string` | `true`   |
+| `repo`  | Exact repository name or comma-separated `collections.MatchItems` patterns. Pattern selectors skip archived repositories. | `string` | `true`   |
+
+### Repository selectors
+
+Use repository selectors when you want one GitHub scraper to discover multiple repositories for the same owner. The `repo` field supports exact names, `*` wildcards, comma-separated patterns, and `!` exclusions from `collections.MatchItems`.
+
+The following example discovers matching repositories for `flanksource`, mixes selector and exact entries, and deduplicates overlapping matches per GitHub scraper config.
+
+```yaml title='github-repo-selectors.yaml' file=<rootDir>/modules/config-db/fixtures/github-repo-selectors.yaml
+
+```
 
 ### SecurityFilters
 

--- a/mission-control/docs/integrations/github.mdx
+++ b/mission-control/docs/integrations/github.mdx
@@ -125,22 +125,10 @@ spec:
 - Track repository settings and branch protection rules
 - Monitor organization membership and access
 
-```yaml title="github-scraper.yaml"
-apiVersion: configs.flanksource.com/v1
-kind: ScrapeConfig
-metadata:
-  name: github-repos
-spec:
-  schedule: "@every 6h"
-  github:
-    - organization: your-org
-      personalAccessToken:
-        valueFrom:
-          secretKeyRef:
-            name: github-credentials
-            key: token
-      repositories:
-        - include: "*"
+The following scraper example imports GitHub repositories into the catalog. The `repo` field supports exact repository names and `collections.MatchItems` selectors, so you can scan a group of repositories without listing every repository.
+
+```yaml title="github-repo-selectors.yaml" file=<rootDir>/modules/config-db/fixtures/github-repo-selectors.yaml
+
 ```
 
 ## Next Steps


### PR DESCRIPTION
Document the GitHub scraper repository selector support added in config-db.

The scraper reference now explains `repositories[].repo` MatchItems patterns, archived-repository filtering, mixed exact/selector entries, and per-config dedupe behavior.

Update the config-db submodule so the docs can import the new `github-repo-selectors.yaml` fixture instead of embedding YAML.