### PR TITLE
chore: remove dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: gomod
-    directory: "/"
-    schedule:
-      interval: daily


### PR DESCRIPTION
Remove the Dependabot configuration from this repository.

Dependency update automation is no longer managed through this repo-level Dependabot config.