### PR TITLE
fix: resolve CodeQL security alerts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   file-ref-check:
     name: file-ref-check

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -2,6 +2,9 @@ name: Vale
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   vale:
     name: runner / vale

--- a/common/src/components/flanksource/Navigation.jsx
+++ b/common/src/components/flanksource/Navigation.jsx
@@ -3,6 +3,15 @@ import React, { useState, useRef } from 'react';
 import { FaChevronDown, FaChevronUp, FaBars, FaTimes, FaBullseye, FaSearch, FaDatabase, FaExclamationTriangle, FaRocket, FaTools, FaLifeRing, FaSync, FaLightbulb, FaEye, FaRobot } from 'react-icons/fa';
 import { SiPostgresql } from 'react-icons/si';
 
+const isGitHubUrl = (href) => {
+  try {
+    const url = new URL(href);
+    return url.protocol === 'https:' && url.hostname === 'github.com';
+  } catch {
+    return false;
+  }
+};
+
 const Navigation = ({
   logo = <img src="/img/mission-control-logo.svg" />,
   loginButton = { href: "https://app.flanksource.com/", text: "Login" },
@@ -241,8 +250,8 @@ const Navigation = ({
                               key={index}
                               href={product.href}
                               className="flex items-start p-1 rounded-lg hover:bg-gray-50 transition-colors"
-                              target={product.href.includes('github.com') ? '_blank' : '_self'}
-                              rel={product.href.includes('github.com') ? 'noopener noreferrer' : ''}
+                              target={isGitHubUrl(product.href) ? '_blank' : '_self'}
+                              rel={isGitHubUrl(product.href) ? 'noopener noreferrer' : ''}
                             >
                               <div className="mr-2 mt-1">{product.icon}</div>
                               <div>
@@ -451,8 +460,8 @@ const Navigation = ({
                           key={index}
                           href={product.href}
                           className="flex items-start p-3 rounded-lg hover:bg-gray-50 transition-colors"
-                          target={product.href.includes('github.com') ? '_blank' : '_self'}
-                          rel={product.href.includes('github.com') ? 'noopener noreferrer' : ''}
+                          target={isGitHubUrl(product.href) ? '_blank' : '_self'}
+                          rel={isGitHubUrl(product.href) ? 'noopener noreferrer' : ''}
                         >
                           <div className="mr-3 mt-1">{product.icon}</div>
                           <div>

--- a/common/src/theme/prism-jq.js
+++ b/common/src/theme/prism-jq.js
@@ -1,7 +1,8 @@
 (function (Prism) {
 
 	var interpolation = /\\\((?:[^()]|\([^()]*\))*\)/.source;
-	var string = RegExp(/(^|[^\\])"(?:[^"\r\n\\]|\\[^\r\n(]|__)*"/.source.replace(/__/g, function () { return interpolation; }));
+	// Keep the string matcher linear-time; interpolation highlighting is handled below.
+	var string = /(^|[^\\])"(?:[^"\r\n\\]|\\[^\r\n])*"/;
 	var stringInterpolation = {
 		'interpolation': {
 			pattern: RegExp(/((?:^|[^\\])(?:\\{2})*)/.source + interpolation),


### PR DESCRIPTION
CodeQL reported open alerts for workflow token permissions, unsafe GitHub URL detection, and a jq Prism regex with ReDoS risk.

Restrict workflow GITHUB_TOKEN permissions to read-only, validate GitHub links by exact URL hostname, and simplify the jq string matcher to avoid exponential backtracking.