### PR TITLE
fix: use upstream DigitalOcean Vale package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,7 @@
 	commit = 8897c67d86a15ce1afcdec26ada3ccf29133c34a
 [submodule "docs-vale-package"]
 	path = docs-vale-package
-	url = https://github.com/flanksource/docs-vale-package
+	url = https://github.com/digitalocean/vale-package
 [submodule "modules/duty"]
 	path = modules/duty
 	url = https://github.com/flanksource/duty.git


### PR DESCRIPTION
The Flanksource fork used by the `docs-vale-package` submodule was deleted.

Update the submodule URL to reference `digitalocean/vale-package` directly. The pinned commit remains available upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation tooling source to use the new repository location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->