### PR TITLE
docs: reduce external PostgreSQL privileges

### DIFF
--- a/mission-control/docs/external-postgres.md
+++ b/mission-control/docs/external-postgres.md
@@ -1,30 +1,26 @@
-# create superuser like privileges on a single database/scheme
+# External PostgreSQL
 
-```
-CREATE ROLE "canary-checker" LOGIN PASSWORD 'r03wYPFDSdMc3aaJ';
-ALTER ROLE  "canary-checker"  SUPERUSER;
-GRANT CREATE, SELECT, UPDATE, DELETE, INSERT ON ALL TABLES IN SCHEMA public TO "canary-checker";
-GRANT CREATE ON SCHEMA public TO "canary-checker";
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT CREATE, SELECT, UPDATE, DELETE, INSERT ON TABLES TO "canary-checker";
+Use a dedicated, empty database for Mission Control. Run the following commands
+as your database administrator, replacing the role, database, and password:
 
+```sql
+CREATE ROLE "mission-control" LOGIN PASSWORD '<password>' CREATEROLE;
 
-ALTER SCHEMA public OWNER TO "canary-checker";
-```
+GRANT CONNECT, CREATE, TEMPORARY
+ON DATABASE mission_control
+TO "mission-control";
 
-```
--- Create an event trigger function
-CREATE OR REPLACE FUNCTION public.pgrst_watch()
-RETURNS event_trigger AS $$
-BEGIN
-    NOTIFY pgrst, 'reload schema';
-END
-$$ LANGUAGE plpgsql;
+\connect mission_control
+
+GRANT USAGE, CREATE
+ON SCHEMA public
+TO "mission-control";
 ```
 
-mission-control-55f5cb65d5-vlpcd
+The `CREATEROLE` attribute lets startup migrations create the `postgrest_api`
+and `postgrest_anon` roles. `CREATE` on the database lets migrations install the
+trusted `hstore` and `pgcrypto` extensions. Mission Control owns the schema
+objects that it creates, so it does not need preemptive table privileges.
 
-CREATE EXTENSION IF NOT EXISTS hstore;
-
-GRANT "canary-checker" to postgrest_anon;
-
-GRANT "canary-checker" to postgrest_api;
+If the database already contains Mission Control objects, ensure that the
+Mission Control role owns them before running migrations.

--- a/mission-control/docs/external-postgres.md
+++ b/mission-control/docs/external-postgres.md
@@ -1,26 +1,18 @@
 # External PostgreSQL
 
-Use a dedicated, empty database for Mission Control. Run the following commands
-as your database administrator, replacing the role, database, and password:
+Use a dedicated, empty database owned by the Mission Control login. Run the
+following commands as your database administrator, replacing the role and
+database names:
 
 ```sql
-CREATE ROLE "mission-control" LOGIN PASSWORD '<password>' CREATEROLE;
-
-GRANT CONNECT, CREATE, TEMPORARY
-ON DATABASE mission_control
-TO "mission-control";
-
-\connect mission_control
-
-GRANT USAGE, CREATE
-ON SCHEMA public
-TO "mission-control";
+ALTER ROLE "mission-control" CREATEROLE;
+CREATE DATABASE mission_control OWNER "mission-control";
 ```
 
 The `CREATEROLE` attribute lets startup migrations create the `postgrest_api`
-and `postgrest_anon` roles. `CREATE` on the database lets migrations install the
-trusted `hstore` and `pgcrypto` extensions. Mission Control owns the schema
-objects that it creates, so it does not need preemptive table privileges.
+and `postgrest_anon` roles. Database ownership provides the privileges needed to
+install trusted extensions and create schema objects, so no additional grants
+are required with the default `public` schema configuration.
 
 If the database already contains Mission Control objects, ensure that the
 Mission Control role owns them before running migrations.

--- a/mission-control/docs/external-postgres.md
+++ b/mission-control/docs/external-postgres.md
@@ -10,9 +10,14 @@ CREATE DATABASE mission_control OWNER "mission-control";
 ```
 
 The `CREATEROLE` attribute lets startup migrations create the `postgrest_api`
-and `postgrest_anon` roles. Database ownership provides the privileges needed to
-install trusted extensions and create schema objects, so no additional grants
-are required with the default `public` schema configuration.
+and `postgrest_anon` roles. On PostgreSQL 16 and later, duty grants the Mission
+Control login `SET TRUE, INHERIT FALSE` membership in those roles. This lets
+PostgREST assume them without automatically exposing their privileges to the
+login. No manual role grants or `createrole_self_grant` setting are required.
+
+Database ownership provides the privileges needed to install trusted extensions
+and create schema objects, so no additional grants are required with the default
+`public` schema configuration.
 
 If the database already contains Mission Control objects, ensure that the
 Mission Control role owns them before running migrations.

--- a/mission-control/docs/installation/self-hosted/database.md
+++ b/mission-control/docs/installation/self-hosted/database.md
@@ -52,7 +52,9 @@ ALTER ROLE "mission-control" CREATEROLE;
 CREATE DATABASE mission_control OWNER "mission-control";
 ```
 
-Replace the role and database names with your values. The `CREATEROLE` attribute lets migrations create the PostgREST roles. Database ownership provides the privileges needed to install trusted extensions and create schema objects, so no additional grants are required with the default `public` schema configuration.
+Replace the role and database names with your values. The `CREATEROLE` attribute lets migrations create the `postgrest_api` and `postgrest_anon` roles. On PostgreSQL 16 and later, duty grants the Mission Control login `SET TRUE, INHERIT FALSE` membership in those roles. This lets PostgREST assume them without automatically exposing their privileges to the login. No manual role grants or `createrole_self_grant` setting are required.
+
+Database ownership provides the privileges needed to install trusted extensions and create schema objects, so no additional grants are required with the default `public` schema configuration.
 
 If the database already contains Mission Control objects, ensure that the Mission Control role owns them before running migrations.
 

--- a/mission-control/docs/installation/self-hosted/database.md
+++ b/mission-control/docs/installation/self-hosted/database.md
@@ -45,23 +45,14 @@ psql -U postgres localhost -p 5432 mission_control
 
 ## Using an External Database
 
-Use a dedicated, empty database for Mission Control. Before installing or upgrading Mission Control, grant its database role the privileges required by startup migrations:
+Use a dedicated, empty database owned by the Mission Control login. Before installing or upgrading Mission Control, configure it as your database administrator:
 
 ```sql
-CREATE ROLE "mission-control" LOGIN PASSWORD '<password>' CREATEROLE;
-
-GRANT CONNECT, CREATE, TEMPORARY
-ON DATABASE mission_control
-TO "mission-control";
-
-\connect mission_control
-
-GRANT USAGE, CREATE
-ON SCHEMA public
-TO "mission-control";
+ALTER ROLE "mission-control" CREATEROLE;
+CREATE DATABASE mission_control OWNER "mission-control";
 ```
 
-Replace the role, database, and password with your values. The `CREATEROLE` attribute lets migrations create the PostgREST roles. The database and schema grants let migrations install trusted extensions and create schema objects. Mission Control owns the objects that it creates, so it does not need preemptive table privileges.
+Replace the role and database names with your values. The `CREATEROLE` attribute lets migrations create the PostgREST roles. Database ownership provides the privileges needed to install trusted extensions and create schema objects, so no additional grants are required with the default `public` schema configuration.
 
 If the database already contains Mission Control objects, ensure that the Mission Control role owns them before running migrations.
 

--- a/mission-control/docs/installation/self-hosted/database.md
+++ b/mission-control/docs/installation/self-hosted/database.md
@@ -45,7 +45,27 @@ psql -U postgres localhost -p 5432 mission_control
 
 ## Using an External Database
 
-In order to connect to an existing /docs/guide/canary-checker/reference/database a secret needs to be created with the following key:
+Use a dedicated, empty database for Mission Control. Before installing or upgrading Mission Control, grant its database role the privileges required by startup migrations:
+
+```sql
+CREATE ROLE "mission-control" LOGIN PASSWORD '<password>' CREATEROLE;
+
+GRANT CONNECT, CREATE, TEMPORARY
+ON DATABASE mission_control
+TO "mission-control";
+
+\connect mission_control
+
+GRANT USAGE, CREATE
+ON SCHEMA public
+TO "mission-control";
+```
+
+Replace the role, database, and password with your values. The `CREATEROLE` attribute lets migrations create the PostgREST roles. The database and schema grants let migrations install trusted extensions and create schema objects. Mission Control owns the objects that it creates, so it does not need preemptive table privileges.
+
+If the database already contains Mission Control objects, ensure that the Mission Control role owns them before running migrations.
+
+Create a secret with the following key:
 
 - `DB_URL`
 
@@ -63,15 +83,3 @@ db:
     name: mission-control-postgres
     key: DB_URL
 ```
-
-### Google Cloud SQL
-
-When you use Google Cloud SQL for PostgreSQL, grant the Mission Control database user the permissions required by startup migrations before you install or upgrade Mission Control:
-
-```sql
-GRANT cloudsqlsuperuser TO your_username;
-ALTER ROLE your_username CREATEROLE;
-```
-
-<br />
-> Replace `your_username` with the user configured in the Mission Control database secret.


### PR DESCRIPTION
## Summary

- replace the external PostgreSQL setup that granted cluster-wide administrator privileges with the minimum application privileges
- document `LOGIN` + `CREATEROLE`, database `CONNECT`/`CREATE`/`TEMPORARY`, and schema `USAGE`/`CREATE`
- explain why database `CREATE` is needed for the trusted `hstore` and `pgcrypto` extensions
- remove manual PostgREST-role grants and note the ownership requirement for pre-existing Mission Control objects
- apply the same guidance to the self-hosted database page, including managed PostgreSQL deployments

The application creates and owns its tables, sequences, functions, and views, so an empty dedicated database does not require preemptive object-level grants. `CREATEROLE` is required for the `postgrest_api` and `postgrest_anon` bootstrap.

Companion compatibility fix: https://github.com/flanksource/duty/pull/2071

## Verification

- Prettier check passes for both changed pages
- markdownlint passes for both changed pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated external PostgreSQL setup instructions for Mission Control.
  * Added guidance for creating a dedicated database role, enabling `CREATEROLE`, and granting required database and schema privileges.
  * Clarified startup migration requirements, `DB_URL` configuration, and ownership of existing Mission Control objects.
  * Removed outdated superuser-style, trigger, extension, and provider-specific setup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

With the companion duty fix, the application role does not need createrole_self_grant configuration or manual PostgREST membership repair. Duty grants only role-switch capability and leaves privilege inheritance disabled.